### PR TITLE
BF: more type-casting for python 2.7

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,8 @@
 History
 =======
 
-- made get_list_of_choices() work properly with Python 2.7.9
+- made get_list_of_choices(), get_choice(), get_string(), and get_directory_name()
+  work properly with Python 2.7.9
 
 0.2.3a
 ------

--- a/easygui_qt/easygui_qt.py
+++ b/easygui_qt/easygui_qt.py
@@ -463,6 +463,8 @@ def get_string(message="Enter your response", title="Title",
                                           QtGui.QLineEdit.Normal,
                                           default_response, flags)
     if ok:
+        if sys.version_info < (3,):
+            return unicode(text)
         return text
 
 @with_app
@@ -490,6 +492,8 @@ def get_choice(message="Select one item", title="Title", choices=None):
     choice, ok = QtGui.QInputDialog.getItem(None, title,
             message, choices, 0, False, flags)
     if ok:
+        if sys.version_info < (3,):
+            return unicode(choice)
         return choice
 
 
@@ -538,6 +542,8 @@ def get_directory_name(title="Get directory"):
     options |= QtGui.QFileDialog.ShowDirsOnly
     directory = QtGui.QFileDialog.getExistingDirectory(None,
                                             title, os.getcwd(), options)
+    if sys.version_info < (3,):
+        return unicode(directory)
     return directory
 
 


### PR DESCRIPTION
- fixed: get_choice, get_string, and get_directory_name
- not fixed: get_file_names, get_save_file_name (due to other errors when trying to call the function)
