### PR TITLE
BF: pass lists to subprocess.check_output() in launcher demo

### DIFF
--- a/easygui_qt/demos/launcher.py
+++ b/easygui_qt/demos/launcher.py
@@ -20,11 +20,11 @@ def launch(name):
     filename = '_launch_widget.py'
     if __name__ != "__main__":
         filename = os.path.join(os.path.dirname(__file__), filename)
-    if LOCALE is None:
-        output = subprocess.check_output('python {} {}'.format(filename, name))
-    else:
-        output = subprocess.check_output(
-                              'python {} {} {}'.format(filename, name, LOCALE))
+
+    command = ['python', filename, name]
+    if LOCALE:
+        command.append(LOCALE)
+    output = subprocess.check_output(command)
 
     try:
         output = output.decode(encoding='UTF-8')


### PR DESCRIPTION
- hopefully lists work here in python 3
- a side-benefit of using lists: automatically handles white-space in filenames
- not sure whether "if LOCALE:" needs to be "if LOCALE  is not None:" (per logic in original code). I doubt that it matters (empty list or empty string? int 0?)
