### PR TITLE
Improved keyboard usage with multichoice selector

### DIFF
--- a/easygui_qt/multichoice.py
+++ b/easygui_qt/multichoice.py
@@ -74,6 +74,14 @@ class MultipleChoicesDialog(QtGui.QDialog):
         self.selection = []
         self.close()
 
+    def keyPressEvent(self, e):
+        if e.key() == QtCore.Qt.Key_Escape:
+            self.cancel()
+        elif e.key() == QtCore.Qt.Key_Enter:
+            self.selection_completed()
+        else:
+            super(MultipleChoicesDialog, self).keyPressEvent(e)
+
 if __name__ == '__main__':
     app = QtGui.QApplication([])
     dialog = MultipleChoicesDialog()

--- a/easygui_qt/multichoice.py
+++ b/easygui_qt/multichoice.py
@@ -41,10 +41,10 @@ class MultipleChoicesDialog(QtGui.QDialog):
         cancel_btn.clicked.connect(self.cancel)
 
         button_box = QtGui.QWidget()
-        button_box_layout.addWidget(select_all_btn, 0, 0)
-        button_box_layout.addWidget(clear_all_btn, 1, 0)
+        button_box_layout.addWidget(selection_completed_btn, 0, 0)
         button_box_layout.addWidget(cancel_btn, 0, 1)
-        button_box_layout.addWidget(selection_completed_btn, 1, 1)
+        button_box_layout.addWidget(select_all_btn, 1, 0)
+        button_box_layout.addWidget(clear_all_btn, 1, 1)
         button_box.setLayout(button_box_layout)
 
         main_layout.addWidget(button_box)


### PR DESCRIPTION
Great project, appreciate the effort that's gone into it.

I found the multi-choice selector to be a bit awkwardly arranged for keyboard input. The button layout was in the order: 

1. Select all
2. Clear all
3. Ok
4. Cancel

This put the default selection focus on select all. So when using with a keyboard, after makign the selection the user presses Enter with the intention to finalize, what actually happens is that all choices are selected. This is easily fixed by placing the buttons in the order Ok, Cancel, Select All, Clear All.

This provides the least amount of surprise for a keyboard-warrior user, and also conforms to the idea that the muti-choices default action should be finalize, and not selecting all.

Additionally, there is a bug in this selector. I will raise a separate issue regarding it.
