### PR TITLE
updated to work with PyQt5

### DIFF
--- a/easygui_qt/calendar_widget.py
+++ b/easygui_qt/calendar_widget.py
@@ -1,30 +1,30 @@
 
 try:
-    from PyQt4 import QtGui, QtCore
+    from PyQt5 import QtGui, QtCore, QtWidgets
 except ImportError:
-    from PyQt5 import QtGui, QtCore  # untested
-
-class CalendarWidget(QtGui.QWidget):
+    print("Error importing PyQt5. Have you installed it?")
+    
+class CalendarWidget(QtWidgets.QWidget):
     """Creates a calendar widget allowing the user to select a date."""
     def __init__(self, title="Calendar"):
         super(CalendarWidget, self).__init__()
 
         self.setWindowTitle(title)
-        layout = QtGui.QGridLayout()
+        layout = QtWidgets.QGridLayout()
         layout.setColumnStretch(1, 1)
 
-        self.cal = QtGui.QCalendarWidget(self)
+        self.cal = QtWidgets.QCalendarWidget(self)
         self.cal.setGridVisible(True)
         self.cal.clicked[QtCore.QDate].connect(self.show_date)
         layout.addWidget(self.cal, 0, 0, 1, 2)
 
-        self.date_label = QtGui.QLabel()
+        self.date_label = QtWidgets.QLabel()
         self.date = self.cal.selectedDate()
         self.date_label.setText(self.date.toString())
         layout.addWidget(self.date_label, 1, 0)
 
-        button_box = QtGui.QDialogButtonBox()
-        confirm_button = button_box.addButton(QtGui.QDialogButtonBox.Ok)
+        button_box = QtWidgets.QDialogButtonBox()
+        confirm_button = button_box.addButton(QtWidgets.QDialogButtonBox.Ok)
         confirm_button.clicked.connect(self.confirm)
         layout.addWidget(button_box, 1, 1)
 
@@ -42,7 +42,7 @@ class CalendarWidget(QtGui.QWidget):
 
 if __name__ == '__main__':
     import sys
-    app = QtGui.QApplication([])
+    app = QtWidgets.QApplication([])
     cal = CalendarWidget(title="title")
     app.exec_()
     date = cal.date.toString()

--- a/easygui_qt/demos/launcher.py
+++ b/easygui_qt/demos/launcher.py
@@ -11,10 +11,10 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../"))
 import easygui_qt
 
 try:
-    from PyQt4 import QtGui, QtCore
+    from PyQt5 import QtGui, QtCore, QtWidgets
 except ImportError:
-    from PyQt5 import QtGui, QtCore  # untested
-
+    print("Error importing PyQt5. Have you installed it?")\
+                 
 def launch(name, *args):
     """Executes a script designed specifically for this launcher.
 
@@ -38,14 +38,14 @@ def launch(name, *args):
     return output
 
 
-class Dialog(QtGui.QDialog):
+class Dialog(QtWidgets.QDialog):
 
     def __init__(self, parent=None):
         flags = QtCore.Qt.WindowSystemMenuHint | QtCore.Qt.WindowTitleHint
         super(Dialog, self).__init__(parent, flags=flags)
 
-        frameStyle = QtGui.QFrame.Sunken | QtGui.QFrame.Panel
-        layout = QtGui.QGridLayout()
+        frameStyle = QtWidgets.QFrame.Sunken | QtWidgets.QFrame.Panel
+        layout = QtWidgets.QGridLayout()
         layout.setColumnStretch(1, 1)
         layout.setColumnMinimumWidth(1, 250)
 
@@ -71,17 +71,17 @@ class Dialog(QtGui.QDialog):
                 'get_language', 'set_font_size',
                 'show_file', 'show_code', 'get_abort', 'find_help']
         for n, fxn in enumerate(fxns):
-            self.button[fxn] = QtGui.QPushButton(fxn + "()")
+            self.button[fxn] = QtWidgets.QPushButton(fxn + "()")
             self.button[fxn].clicked.connect(getattr(self, fxn))
             self.button[fxn].setToolTip(getattr(easygui_qt, fxn).__doc__)
-            self.label[fxn] = QtGui.QLabel()
+            self.label[fxn] = QtWidgets.QLabel()
             self.label[fxn].setFrameStyle(frameStyle)
             layout.addWidget(self.button[fxn], n, 0)
             layout.addWidget(self.label[fxn], n, 1)
 
         # handle special-case display items separately:
         n += 1
-        self.python_version_label = QtGui.QLabel()
+        self.python_version_label = QtWidgets.QLabel()
         layout.addWidget(self.python_version_label, n, 0, 2, 2)
         output = subprocess.check_output(
                          ['python', '-c', "import sys;print(sys.version)"])
@@ -90,11 +90,11 @@ class Dialog(QtGui.QDialog):
 
         n += 2
 
-        self.cancel_btn = QtGui.QPushButton("Quit")
+        self.cancel_btn = QtWidgets.QPushButton("Quit")
         self.cancel_btn.clicked.connect(self.close)
         layout.addWidget(self.cancel_btn, n, 0)
 
-        self.handle_exception_label = QtGui.QLabel()
+        self.handle_exception_label = QtWidgets.QLabel()
         self.handle_exception_label.setToolTip(
                                   easygui_qt.handle_exception.__doc__)
         self.handle_exception_label.setText(" handle_exception() not shown" +
@@ -220,7 +220,7 @@ class Dialog(QtGui.QDialog):
         launch('find_help')
 
 def main():
-    _ = QtGui.QApplication([])
+    _ = QtWidgets.QApplication([])
     dialog = Dialog()
     dialog.exec_()
 

--- a/easygui_qt/easygui_qt.py
+++ b/easygui_qt/easygui_qt.py
@@ -15,10 +15,9 @@ else:
     unicode = str
 
 try:
-    from PyQt4 import QtGui, QtCore
+    from PyQt5 import QtGui, QtCore, QtWidgets
 except ImportError:
-    from PyQt5 import QtGui, QtCore  # untested
-
+    print("Error importing PyQt5. Have you installed it?")
 
 try:
     from . import utils
@@ -71,7 +70,7 @@ __all__ = [
 QM_FILES = None
 
 
-class SimpleApp(QtGui.QApplication):
+class SimpleApp(QtWidgets.QApplication):
     """A simple extention of the basic QApplication
        with added methods useful for working with dialogs
        that are not class based.
@@ -173,7 +172,7 @@ def show_message(message="Message",
        .. image:: ../docs/images/show_message.png
     """
     app = SimpleApp()
-    box = QtGui.QMessageBox(None)
+    box = QtWidgets.QMessageBox(None)
     box.setWindowTitle(title)
     box.setText(message)
     box.show()
@@ -197,16 +196,16 @@ def get_yes_or_no(message="Answer this question", title="Title"):
        .. image:: ../docs/images/yes_no_question.png
     """
     app = SimpleApp()
-    flags = QtGui.QMessageBox.Yes | QtGui.QMessageBox.No
-    flags |= QtGui.QMessageBox.Cancel
+    flags = QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No
+    flags |= QtWidgets.QMessageBox.Cancel
 
-    box = QtGui.QMessageBox()
+    box = QtWidgets.QMessageBox()
     box.show()
     box.raise_()
 
     reply = box.question(None, title, message, flags)
     app.quit()
-    return reply == QtGui.QMessageBox.Yes
+    return reply == QtWidgets.QMessageBox.Yes
 
 
 def get_continue_or_cancel(message="Processed will be cancelled!",
@@ -229,16 +228,16 @@ def get_continue_or_cancel(message="Processed will be cancelled!",
        .. image:: ../docs/images/get_continue_or_cancel.png
     """
     app = SimpleApp()
-    message_box = QtGui.QMessageBox(QtGui.QMessageBox.Warning, title, message,
-                                    QtGui.QMessageBox.NoButton)
-    message_box.addButton(continue_button_text, QtGui.QMessageBox.AcceptRole)
-    message_box.addButton(cancel_button_text, QtGui.QMessageBox.RejectRole)
+    message_box = QtWidgets.QMessageBox(QtWidgets.QMessageBox.Warning, title, message,
+                                    QtWidgets.QMessageBox.NoButton)
+    message_box.addButton(continue_button_text, QtWidgets.QMessageBox.AcceptRole)
+    message_box.addButton(cancel_button_text, QtWidgets.QMessageBox.RejectRole)
     message_box.show()
     message_box.raise_()
 
     reply = message_box.exec_()
     app.quit()
-    return reply == QtGui.QMessageBox.AcceptRole
+    return reply == QtWidgets.QMessageBox.AcceptRole
 
 
 #============= Color dialogs =================
@@ -253,7 +252,7 @@ def get_color_hex():
        .. image:: ../docs/images/select_color.png
        """
     app = SimpleApp()
-    color = QtGui.QColorDialog.getColor(QtCore.Qt.white, None)
+    color = QtWidgets.QColorDialog.getColor(QtCore.Qt.white, None)
     app.quit()
     if color.isValid():
         return color.name()
@@ -269,7 +268,7 @@ def get_color_rgb(app=None):
        .. image:: ../docs/images/select_color_fr.png
        """
     app = SimpleApp()
-    color = QtGui.QColorDialog.getColor(QtCore.Qt.white, None)
+    color = QtWidgets.QColorDialog.getColor(QtCore.Qt.white, None)
     app.quit()
     if color.isValid():
         return (color.red(), color.green(), color.blue())
@@ -358,7 +357,7 @@ def get_common_input_flags():
     flags |= QtCore.Qt.WindowStaysOnTopHint
     return flags
 
-class VisibleInputDialog(QtGui.QInputDialog):
+class VisibleInputDialog(QtWidgets.QInputDialog):
     '''A simple InputDialog class that attempts to make itself automatically
        on all platforms
     '''
@@ -412,7 +411,7 @@ def get_int(message="Choose a number", title="Title",
     app = SimpleApp()
     dialog = VisibleInputDialog()
     flags = get_common_input_flags()
-    number, ok = dialog.getInteger(None, title, message,
+    number, ok = dialog.getInt(None, title, message,
                                    default_value, min_, max_, step,
                                    flags)
     dialog.destroy()
@@ -487,7 +486,7 @@ def get_string(message="Enter your response", title="Title",
     app = SimpleApp()
     dialog = VisibleInputDialog()
     flags = get_common_input_flags()
-    text, ok = dialog.getText(None, title, message, QtGui.QLineEdit.Normal,
+    text, ok = dialog.getText(None, title, message, QtWidgets.QLineEdit.Normal,
                               default_response, flags)
     app.quit()
     if ok:
@@ -514,7 +513,7 @@ def get_password(message="Enter your password", title="Title"):
     app = SimpleApp()
     dialog = VisibleInputDialog()
     flags = get_common_input_flags()
-    text, ok = dialog.getText(None, title, message, QtGui.QLineEdit.Password,
+    text, ok = dialog.getText(None, title, message, QtWidgets.QLineEdit.Password,
                               '', flags)
     app.quit()
     if ok:
@@ -702,13 +701,13 @@ def get_directory_name(title="Get directory"):
        working directory.
     '''
     app = SimpleApp()
-    options = QtGui.QFileDialog.Options()
+    options = QtWidgets.QFileDialog.Options()
     # Without the following option (i.e. using native dialogs),
     # calling this function twice in a row made Python crash.
-    options |= QtGui.QFileDialog.DontUseNativeDialog
-    options |= QtGui.QFileDialog.DontResolveSymlinks
-    options |= QtGui.QFileDialog.ShowDirsOnly
-    directory = QtGui.QFileDialog.getExistingDirectory(None,
+    options |= QtWidgets.QFileDialog.DontUseNativeDialog
+    options |= QtWidgets.QFileDialog.DontResolveSymlinks
+    options |= QtWidgets.QFileDialog.ShowDirsOnly
+    directory = QtWidgets.QFileDialog.getExistingDirectory(None,
                                             title, os.getcwd(), options)
     app.quit()
     if sys.version_info < (3,):
@@ -733,14 +732,14 @@ def get_file_names(title="Get existing file names"):
     '''
     app = SimpleApp()
     if sys.version_info < (3,):
-        files = QtGui.QFileDialog.getOpenFileNames(None, title, os.getcwd(),
+        files = QtWidgets.QFileDialog.getOpenFileNames(None, title, os.getcwd(),
                                                "All Files (*.*)")
         files = [unicode(item) for item in files]
     else:
-        options = QtGui.QFileDialog.Options()
-        options |= QtGui.QFileDialog.DontUseNativeDialog
-        files = QtGui.QFileDialog.getOpenFileNames(None, title, os.getcwd(),
-                                               "All Files (*.*)", options)
+        #options = QtWidgets.QFileDialog.Options()
+        #options |= QtWidgets.QFileDialog.DontUseNativeDialog
+        files = QtWidgets.QFileDialog.getOpenFileNames(None, title, os.getcwd(),
+                                               "All Files (*.*)")#, options)
     app.quit()
     return files
 
@@ -765,15 +764,15 @@ def get_save_file_name(title="File name to save"):
     '''
     app = SimpleApp()
     if sys.version_info < (3,):
-        file_name = QtGui.QFileDialog.getSaveFileName(None, title, os.getcwd(),
+        file_name = QtWidgets.QFileDialog.getSaveFileName(None, title, os.getcwd(),
                                                "All Files (*.*)")
         app.quit()
         return unicode(file_name)
 
-    options = QtGui.QFileDialog.Options()
-    options |= QtGui.QFileDialog.DontUseNativeDialog  # see get_directory_name
-    file_name = QtGui.QFileDialog.getSaveFileName(None, title, os.getcwd(),
-                                               "All Files (*.*)", options)
+    #options = QtWidgets.QFileDialog.Options()
+    #options |= QtWidgets.QFileDialog.DontUseNativeDialog  # see get_directory_name
+    file_name = QtWidgets.QFileDialog.getSaveFileName(None, title, os.getcwd(),
+                                               "All Files (*.*)")#, options)
     app.quit()
     return file_name
 
@@ -899,9 +898,9 @@ def get_abort(message="Major problem - or at least we think there is one...",
     '''
 
     app = SimpleApp()
-    reply = QtGui.QMessageBox.critical(None, title, message,
-            QtGui.QMessageBox.Abort | QtGui.QMessageBox.Ignore)
-    if reply == QtGui.QMessageBox.Abort:
+    reply = QtWidgets.QMessageBox.critical(None, title, message,
+            QtWidgets.QMessageBox.Abort | QtWidgets.QMessageBox.Ignore)
+    if reply == QtWidgets.QMessageBox.Abort:
         sys.exit()
     else:
         pass

--- a/easygui_qt/language_selector.py
+++ b/easygui_qt/language_selector.py
@@ -5,11 +5,11 @@ except:
     import utils
 
 try:
-    from PyQt4 import QtGui, QtCore
+    from PyQt5 import QtGui, QtCore, QtWidgets
 except ImportError:
-    from PyQt5 import QtGui, QtCore  # untested
+    print("Error importing PyQt5. Have you installed it?")
 
-class LanguageSelector(QtGui.QDialog):
+class LanguageSelector(QtWidgets.QDialog):
     """A specially constructed dialog which uses informations about
        available language (qm) files which can be used to change the
        default language of the basic PyQt ui components.
@@ -26,10 +26,10 @@ class LanguageSelector(QtGui.QDialog):
         qm_files = utils.find_qm_files()
 
         # ========= check boxes ==============
-        group_box = QtGui.QGroupBox(name)
-        group_box_layout = QtGui.QGridLayout()
+        group_box = QtWidgets.QGroupBox(name)
+        group_box_layout = QtWidgets.QGridLayout()
         for i, locale in enumerate(qm_files):
-            check_box = QtGui.QCheckBox(locale)
+            check_box = QtWidgets.QCheckBox(locale)
             check_box.setAutoExclusive(True)
             self.qm_files_choices[check_box] = locale
             check_box.toggled.connect(self.check_box_toggled)
@@ -37,7 +37,7 @@ class LanguageSelector(QtGui.QDialog):
         # adding default language option. When using the PyQt distribution
         # no "en" files were found and yet "en" was the obvious default.
         # We need this option in case we want to revert a change.
-        check_box = QtGui.QCheckBox("Default")
+        check_box = QtWidgets.QCheckBox("Default")
         check_box.setAutoExclusive(True)
         self.qm_files_choices[check_box] = "default"
         check_box.toggled.connect(self.check_box_toggled)
@@ -46,14 +46,14 @@ class LanguageSelector(QtGui.QDialog):
         group_box.setLayout(group_box_layout)
 
         # ========= buttons ==============
-        button_box = QtGui.QDialogButtonBox()
-        confirm_button = button_box.addButton(QtGui.QDialogButtonBox.Ok)
+        button_box = QtWidgets.QDialogButtonBox()
+        confirm_button = button_box.addButton(QtWidgets.QDialogButtonBox.Ok)
         confirm_button.clicked.connect(self.confirm)
 
         # ========= finalizing layout ====
-        main_layout = QtGui.QVBoxLayout()
+        main_layout = QtWidgets.QVBoxLayout()
         main_layout.addWidget(group_box)
-        main_layout.addWidget(QtGui.QLabel(instruction))
+        main_layout.addWidget(QtWidgets.QLabel(instruction))
         main_layout.addWidget(button_box)
         self.setLayout(main_layout)
         self.setWindowTitle(title)
@@ -72,7 +72,7 @@ class LanguageSelector(QtGui.QDialog):
         self.close()
 
 if __name__ == '__main__':
-    app = QtGui.QApplication([])
+    app = QtWidgets.QApplication([])
     # mocks
     app.config = {'locale': None}
     app.set_locale = lambda x: x

--- a/easygui_qt/multichoice.py
+++ b/easygui_qt/multichoice.py
@@ -2,11 +2,11 @@
 
 import sys
 try:
-    from PyQt4 import QtGui, QtCore
+    from PyQt5 import QtGui, QtCore, QtWidgets
 except ImportError:
-    from PyQt5 import QtGui, QtCore  # untested
-
-class MultipleChoicesDialog(QtGui.QDialog):
+    print("Error importing PyQt5. Have you installed it?")
+    
+class MultipleChoicesDialog(QtWidgets.QDialog):
     """Dialog with the possibility of selecting one or more
        items from a list"""
     def __init__(self, choices=None, title="Title"):
@@ -17,30 +17,30 @@ class MultipleChoicesDialog(QtGui.QDialog):
         self.setWindowTitle(title)
         self.selection = []
 
-        main_widget = QtGui.QWidget()
-        main_layout = QtGui.QVBoxLayout()
+        main_widget = QtWidgets.QWidget()
+        main_layout = QtWidgets.QVBoxLayout()
         main_widget.setLayout(main_layout)
 
-        self.choices_widget = QtGui.QListWidget()
+        self.choices_widget = QtWidgets.QListWidget()
         self.choices_widget.setSelectionMode(
-                                    QtGui.QAbstractItemView.ExtendedSelection)
+                                    QtWidgets.QAbstractItemView.ExtendedSelection)
         for choice in choices:
-            item = QtGui.QListWidgetItem()
+            item = QtWidgets.QListWidgetItem()
             item.setText(choice)
             self.choices_widget.addItem(item)
         main_layout.addWidget(self.choices_widget)
 
-        button_box_layout = QtGui.QGridLayout()
-        selection_completed_btn = QtGui.QPushButton("Ok")
+        button_box_layout = QtWidgets.QGridLayout()
+        selection_completed_btn = QtWidgets.QPushButton("Ok")
         selection_completed_btn.clicked.connect(self.selection_completed)
-        select_all_btn = QtGui.QPushButton("Select all")
+        select_all_btn = QtWidgets.QPushButton("Select all")
         select_all_btn.clicked.connect(self.select_all)
-        clear_all_btn = QtGui.QPushButton("Clear all")
+        clear_all_btn = QtWidgets.QPushButton("Clear all")
         clear_all_btn.clicked.connect(self.clear_all)
-        cancel_btn = QtGui.QPushButton("Cancel")
+        cancel_btn = QtWidgets.QPushButton("Cancel")
         cancel_btn.clicked.connect(self.cancel)
 
-        button_box = QtGui.QWidget()
+        button_box = QtWidgets.QWidget()
         button_box_layout.addWidget(selection_completed_btn, 0, 0)
         button_box_layout.addWidget(cancel_btn, 0, 1)
         button_box_layout.addWidget(select_all_btn, 1, 0)
@@ -83,7 +83,7 @@ class MultipleChoicesDialog(QtGui.QDialog):
             super(MultipleChoicesDialog, self).keyPressEvent(e)
 
 if __name__ == '__main__':
-    app = QtGui.QApplication([])
+    app = QtWidgets.QApplication([])
     dialog = MultipleChoicesDialog()
     dialog.exec_()
     if sys.version_info < (3,):

--- a/easygui_qt/multifields.py
+++ b/easygui_qt/multifields.py
@@ -1,14 +1,14 @@
 import sys
 from collections import OrderedDict
 try:
-    from PyQt4 import QtGui, QtCore
+    from PyQt5 import QtGui, QtCore, QtWidgets
 except ImportError:
-    from PyQt5 import QtGui, QtCore  # untested
-
+    print("Error importing PyQt5. Have you installed it?")
+    
 if sys.version_info >= (3,):
     unicode = str
 
-class MultipleFieldsDialog(QtGui.QDialog):
+class MultipleFieldsDialog(QtWidgets.QDialog):
     """Dialog with multiple fields stored in a dict, with the label
        being the key and the entry being the corresponding value"""
     def __init__(self, labels=None, title="Demo", masks=None, parent=None):
@@ -33,25 +33,25 @@ class MultipleFieldsDialog(QtGui.QDialog):
         if masks is not None:
             assert len(masks) == len(labels)
 
-        layout = QtGui.QGridLayout()
+        layout = QtWidgets.QGridLayout()
         layout.setColumnStretch(1, 1)
         layout.setColumnMinimumWidth(1, 250)
 
         self._labels_ = []
         self.fields = []
         for index, choice in enumerate(labels):
-            self._labels_.append(QtGui.QLabel())
+            self._labels_.append(QtWidgets.QLabel())
             self._labels_[index].setText(choice)
-            self.fields.append(QtGui.QLineEdit())
+            self.fields.append(QtWidgets.QLineEdit())
             self.fields[index].setText('')
             self.parent.o_dict[choice] = ''
             if masks is not None and masks[index]:
-                self.fields[index].setEchoMode(QtGui.QLineEdit.Password)
+                self.fields[index].setEchoMode(QtWidgets.QLineEdit.Password)
             layout.addWidget(self._labels_[index], index, 0)
             layout.addWidget(self.fields[index], index, 1)
 
-        button_box = QtGui.QDialogButtonBox()
-        confirm_button = button_box.addButton(QtGui.QDialogButtonBox.Ok)
+        button_box = QtWidgets.QDialogButtonBox()
+        confirm_button = button_box.addButton(QtWidgets.QDialogButtonBox.Ok)
         layout.addWidget(button_box, index+1, 1)
         confirm_button.clicked.connect(self.confirm)
         self.setLayout(layout)
@@ -68,7 +68,7 @@ class MultipleFieldsDialog(QtGui.QDialog):
 
 
 if __name__ == '__main__':
-    app = QtGui.QApplication([])
+    app = QtWidgets.QApplication([])
     class Parent:
         pass
     parent = Parent()

--- a/easygui_qt/show_text_window.py
+++ b/easygui_qt/show_text_window.py
@@ -6,10 +6,10 @@ The syntax highlighter for Python code is really inadequate;  HELP!! :-)
 """
 
 try:
-    from PyQt4 import QtGui, QtCore
+    from PyQt5 import QtGui, QtCore, QtWidgets
 except ImportError:
-    from PyQt5 import QtGui, QtCore  # untested
-
+    print("Error importing PyQt5. Have you installed it?")
+    
 import keyword
 import sys
 if sys.version_info < (3,):
@@ -18,7 +18,7 @@ else:
     from io import StringIO
 
 
-class TextWindow(QtGui.QMainWindow):
+class TextWindow(QtWidgets.QMainWindow):
     def __init__(self, file_name=None, title="Title", text_type='text',
                  text='Default text'):
         """Simple text window whose input comes from a file, if a file_name 
@@ -31,7 +31,7 @@ class TextWindow(QtGui.QMainWindow):
 
         self.setWindowTitle(title)
         self.resize(900, 600)
-        self.editor = QtGui.QTextEdit(self)
+        self.editor = QtWidgets.QTextEdit(self)
         self.setCentralWidget(self.editor)
         self.editor.setFocus()
 
@@ -130,7 +130,7 @@ class Highlighter(QtGui.QSyntaxHighlighter):
 
 
 if __name__ == '__main__':
-    app = QtGui.QApplication([])
+    app = QtWidgets.QApplication([])
 
     editor1 = TextWindow(file_name="../README.rst",
                          title="Demo of text file",

--- a/easygui_qt/utils.py
+++ b/easygui_qt/utils.py
@@ -2,10 +2,11 @@
 import collections
 import os
 import sys
+
 try:
-    from PyQt4 import QtGui, QtCore
+    from PyQt5 import QtGui, QtCore, QtWidgets
 except ImportError:
-    from PyQt5 import QtGui, QtCore  # untested
+    print("Error importing PyQt5. Have you installed it?")
 
 if sys.version_info >= (3,):
     unicode = str
@@ -28,8 +29,8 @@ def create_page(page, parent=None):
        :param page: an interable containing tuples of names of special widget
                     to position as well as their value.
        """
-    new_page = QtGui.QWidget()
-    layout = QtGui.QVBoxLayout()
+    new_page = QtWidgets.QWidget()
+    layout = QtWidgets.QVBoxLayout()
     for kind, value in page:
         if kind.lower() == "text":
             add_text_to_layout(layout, value)
@@ -53,13 +54,13 @@ def create_page(page, parent=None):
 
 def add_text_to_layout(layout, text):
     '''adds some text, as a QLabel, to a layout'''
-    label = QtGui.QLabel(text)
+    label = QtWidgets.QLabel(text)
     label.setWordWrap(True)
     layout.addWidget(label)
 
 def add_image_to_layout(layout, image_file_name):
     '''adds an image, as a QLabel, to a layout'''
-    label =  QtGui.QLabel()
+    label =  QtWidgets.QLabel()
     pixmap =  QtGui.QPixmap(image_file_name)
     label.setPixmap(pixmap)
     layout.addWidget(label)
@@ -67,8 +68,8 @@ def add_image_to_layout(layout, image_file_name):
 def add_list_of_images_to_layout(layout, images):
     ''' adds a list of images shown in a horizontal layout to an
         already existing layout'''
-    h_layout = QtGui.QHBoxLayout()
-    h_box = QtGui.QGroupBox('')
+    h_layout = QtWidgets.QHBoxLayout()
+    h_box = QtWidgets.QGroupBox('')
     for image in images:
         add_image_to_layout(h_layout, image)
     h_box.setLayout(h_layout)
@@ -77,11 +78,11 @@ def add_list_of_images_to_layout(layout, images):
 def add_list_of_images_with_captions_to_layout(layout, images):
     ''' adds a list of images shown in a horizontal layout with
         caption underneath to an already existing layout'''
-    h_layout = QtGui.QHBoxLayout()
-    h_box = QtGui.QGroupBox('')
+    h_layout = QtWidgets.QHBoxLayout()
+    h_box = QtWidgets.QGroupBox('')
     for image, caption in images:
-        widget = QtGui.QWidget()
-        v_layout = QtGui.QVBoxLayout()
+        widget = QtWidgets.QWidget()
+        v_layout = QtWidgets.QVBoxLayout()
         add_image_to_layout(v_layout, image)
         add_text_to_layout(v_layout, caption)
         widget.setLayout(v_layout)
@@ -92,11 +93,11 @@ def add_list_of_images_with_captions_to_layout(layout, images):
 def add_list_of_images_with_buttons_to_layout(layout, images, parent):
     ''' adds a list of images shown in a horizontal layout with
         button underneath to an already existing layout'''
-    h_layout = QtGui.QHBoxLayout()
-    h_box = QtGui.QGroupBox('')
+    h_layout = QtWidgets.QHBoxLayout()
+    h_box = QtWidgets.QGroupBox('')
     for image, label in images:
-        widget = QtGui.QWidget()
-        v_layout = QtGui.QVBoxLayout()
+        widget = QtWidgets.QWidget()
+        v_layout = QtWidgets.QVBoxLayout()
         add_image_to_layout(v_layout, image)
         add_button(v_layout, label, parent)
         widget.setLayout(v_layout)
@@ -107,22 +108,22 @@ def add_list_of_images_with_buttons_to_layout(layout, images, parent):
 def add_list_of_buttons_to_layout(layout, button_labels, parent):
     ''' adds a list of buttons shown in a horizontal layout to an
         already existing layout'''
-    h_layout = QtGui.QHBoxLayout()
-    h_box = QtGui.QGroupBox('')
+    h_layout = QtWidgets.QHBoxLayout()
+    h_box = QtWidgets.QGroupBox('')
     for label in button_labels:
         add_button(h_layout, label, parent)
     h_box.setLayout(h_layout)
     layout.addWidget(h_box)
 
 def add_button(layout, label, parent):
-    btn = QtGui.QPushButton(label)
+    btn = QtWidgets.QPushButton(label)
     btn.clicked.connect(parent.button_clicked)
     width = btn.fontMetrics().boundingRect(label).width() + 15
     btn.setMaximumWidth(width)
     layout.addWidget(btn)
 
 
-class MyPageDialog(QtGui.QDialog):
+class MyPageDialog(QtWidgets.QDialog):
     """Creates a "complex" dialog based on a description as a "page"."""
     def __init__(self, title="title", page=None, response=None):
         super(MyPageDialog, self).__init__(None,
@@ -133,7 +134,7 @@ class MyPageDialog(QtGui.QDialog):
             raise AttributeError
         self.response = response
 
-        layout = QtGui.QVBoxLayout()
+        layout = QtWidgets.QVBoxLayout()
         widget = create_page(page, parent=self)
         layout.addWidget(widget)
         self.setLayout(layout)
@@ -145,7 +146,7 @@ class MyPageDialog(QtGui.QDialog):
 
 
 if __name__ == '__main__':
-    app = QtGui.QApplication([])
+    app = QtWidgets.QApplication([])
     page = [("text", "This is a sample text"),
             ("image", "../ignore/images/python.jpg"),
             ("text", "More text"),

--- a/easygui_qt/wizard_maker.py
+++ b/easygui_qt/wizard_maker.py
@@ -1,10 +1,10 @@
 
 try:
-    from PyQt4 import QtGui, QtCore
+    from PyQt5 import QtGui, QtCore, QtWidgets
 except ImportError:
-    from PyQt5 import QtGui, QtCore  # untested
-
-class WizardCreator(QtGui.QWizard):
+    print("Error importing PyQt5. Have you installed it?")
+    
+class WizardCreator(QtWidgets.QWizard):
     def __init__(self, title="Title", pages=[]):
         super(WizardCreator, self).__init__(None,
               QtCore.Qt.WindowSystemMenuHint | QtCore.Qt.WindowTitleHint)
@@ -14,25 +14,25 @@ class WizardCreator(QtGui.QWizard):
         self.show()
 
     def create_page(self, page):
-        new_page = QtGui.QWizardPage()
-        layout = QtGui.QVBoxLayout()
+        new_page = QtWidgets.QWizardPage()
+        layout = QtWidgets.QVBoxLayout()
         for kind, value in page:
             if kind.lower() == "title":
                 new_page.setTitle(value)
             elif kind.lower() == "text":
-                label = QtGui.QLabel(value)
+                label = QtWidgets.QLabel(value)
                 label.setWordWrap(True)
                 layout.addWidget(label)
             elif kind.lower() == "image":
-                label =  QtGui.QLabel()
+                label =  QtWidgets.QLabel()
                 pixmap =  QtGui.QPixmap(value)
                 label.setPixmap(pixmap)
                 layout.addWidget(label)
             elif kind.lower() == "many images":
-                h_layout = QtGui.QHBoxLayout()
-                h_box = QtGui.QGroupBox('')
+                h_layout = QtWidgets.QHBoxLayout()
+                h_box = QtWidgets.QGroupBox('')
                 for image in value:
-                    label =  QtGui.QLabel()
+                    label =  QtWidgets.QLabel()
                     pixmap =  QtGui.QPixmap(image)
                     label.setPixmap(pixmap)
                     h_layout.addWidget(label)
@@ -42,7 +42,7 @@ class WizardCreator(QtGui.QWizard):
         self.addPage(new_page)
 
 if __name__ == '__main__':
-    app = QtGui.QApplication([])
+    app = QtWidgets.QApplication([])
     page1 = [("text", "This is a sample text"),
              ("image", "../ignore/images/python.jpg"),
              ("text", "More text")]

--- a/setup.py
+++ b/setup.py
@@ -20,20 +20,20 @@ test_requirements = [
 ]
 
 setup(
-    name='easygui_qt',
-    version='0.9.2',
+    name='cs20-gui',
+    version='0.9.3',
     description='"Inspired by EasyGUI, designed for PyQt"',
     long_description=readme + '\n\n' + history,
     author='André Roberge',
     author_email='andre.roberge@gmail.com',
-    url='https://github.com/aroberge/easygui_qt',
+    url='https://github.com/schellenberg/easygui_qt',
     packages=[
         'easygui_qt', 'easygui_qt.demos'
     ],
     package_dir={'easygui_qt':
                  'easygui_qt'},
     include_package_data=True,
-    install_requires='',
+    install_requires=['sip', 'PyQt5'],
     license="BSD",
     zip_safe=False,
     keywords='easygui_qt',


### PR DESCRIPTION
PyQt5 changes the location of some GUI elements, by splitting up QtGui into QtGui and QtWidgets. Many previous calls to QtGui needed to be changed to QtWidgets instead. A call to .getInteger also needed to be changed to .getInt. Finally, in order for this to work, attempts to import the older PyQt4 were removed, since these changes are not backwards compatible.

Tested on Python 3.6 on Windows 10. 
Minimal testing (really, really basic) done on Python 3.6 and Mac OS X (Sierra)